### PR TITLE
Plugin shouldn't install babel-core in dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
 cache: yarn
 script:
   - yarn
+  - yarn add @babel/core
   - yarn spellcheck
   - yarn lint
   - yarn test

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "spellcheck": "yaspeller-ci *.md",
     "sandbox": "node ./tests/sandbox.js"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@babel/core": "^7.1.6"
   },
   "devDependencies": {


### PR DESCRIPTION
`babel-core` should be in `peerDependencies` 